### PR TITLE
Cross-compile friendly Makefiles

### DIFF
--- a/nfq/Makefile
+++ b/nfq/Makefile
@@ -1,12 +1,12 @@
-CC = gcc
-CFLAGS = -s
+CC ?= gcc
+CFLAGS ?= -s
 LIBS = -lnetfilter_queue -lnfnetlink
 SRC_FILES = *.c
 
 all: nfqws
 
 nfqws: $(SRC_FILES)
-	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 clean:
 	rm -f nfqws *.o

--- a/tpws/Makefile
+++ b/tpws/Makefile
@@ -1,12 +1,12 @@
-CC = gcc
-CFLAGS = -s
+CC ?= gcc
+CFLAGS += -s
 LIBS = 
 SRC_FILES = *.c
 
 all: tpws
 
 tpws: $(SRC_FILES)
-	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 clean:
 	rm -f tpws *.o


### PR DESCRIPTION
Упрощает сборку при кросс-компиляции, в т.ч. в OpenWrt.
Проверено в Entware ([исходники](https://github.com/Entware/graveyard/tree/master/zapret), [бинарники](https://forum.keenetic.net/topic/3078-%D0%BE%D0%B1%D1%85%D0%BE%D0%B4-%D0%B1%D0%BB%D0%BE%D0%BA%D0%B8%D1%80%D0%BE%D0%B2%D0%BE%D0%BA-%D0%BD%D0%B0-%D1%80%D0%BE%D1%83%D1%82%D0%B5%D1%80%D0%B5/?do=findComment&comment=60927)).