### PR TITLE
fix "ask_yes_no: not found"

### DIFF
--- a/uninstall_easy.sh
+++ b/uninstall_easy.sh
@@ -9,6 +9,7 @@ ZAPRET_CONFIG="$EXEDIR/config"
 ZAPRET_BASE="$EXEDIR"
 
 . "$ZAPRET_CONFIG"
+. "$ZAPRET_BASE/common/dialog.sh"
 . "$ZAPRET_BASE/common/base.sh"
 . "$ZAPRET_BASE/common/elevate.sh"
 . "$ZAPRET_BASE/common/fwtype.sh"


### PR DESCRIPTION
Fix missing import "dialog.sh" in "uninstall_easy.sh" script.
Problem was here:
https://github.com/bol-van/zapret/blob/effb6be6e5dfe11ec9aa1b41949b7c4158148b33/common/installer.sh#L114
Fixes #97 