### PR TITLE
readme: openwrt netcat installation

### DIFF
--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -1320,6 +1320,8 @@ curl можно выкинуть, если для получения ip лист
  rm /tmp/zapret-master.zip
 
 Если места совсем мало :
+ opkg update
+ opkg install netcat
  cd /tmp
  nc -l -p 1111 >zapret.tar.gz
 На linux системе скачать и распаковать zapret. Оставить необходимый минимум файлов.


### PR DESCRIPTION
By default OpenWrt comes with busybox-nc (the busybox implementation of netcat) which does not support server mode. You need to install GNU netcat.