### PR TITLE
feat: keenetic support

### DIFF
--- a/init.d/keenetic/custom
+++ b/init.d/keenetic/custom
@@ -1,0 +1,34 @@
+# this script contain your special code to launch daemons and configure firewall
+# use helpers from "functions" file
+# in case of upgrade keep this file only, do not modify others
+
+zapret_custom_daemons()
+{
+	# $1 - 1 - run, 0 - stop
+
+	# PLACEHOLDER
+	echo !!! NEED ATTENTION !!!
+	echo Start daemon\(s\)
+	echo Study how other sections work
+
+	do_daemon $1 1 /bin/sleep 20
+}
+zapret_custom_firewall()
+{
+	# $1 - 1 - run, 0 - stop
+
+	# PLACEHOLDER
+	echo !!! NEED ATTENTION !!!
+	echo Configure iptables for required actions
+	echo Study how other sections work
+}
+
+zapret_custom_firewall_nft()
+{
+	# stop logic is not required
+
+	# PLACEHOLDER
+	echo !!! NEED ATTENTION !!!
+	echo Configure nftables for required actions
+	echo Study how other sections work
+}

--- a/init.d/keenetic/custom-nfqws-quic4all
+++ b/init.d/keenetic/custom-nfqws-quic4all
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# this custom script in addition to MODE=nfqws runs desync to all QUIC initial packets, without ipset/hostlist filtering
+# need to add to config : NFQWS_OPT_DESYNC_QUIC="--dpi-desync=fake"
+# russian TSPU version  : NFQWS_OPT_DESYNC_QUIC="--dpi-desync=fake --dpi-desync-fake-quic=/opt/zapret/files/fake/quic_short_header.bin"
+# NOTE : do not use TTL fooling. chromium QUIC engine breaks sessions if TTL expired in transit received
+
+QNUM2=$(($QNUM+10))
+
+zapret_custom_daemons()
+{
+	# $1 - 1 - run, 0 - stop
+
+	local MODE_OVERRIDE=nfqws
+	local opt
+
+	zapret_do_daemons $1
+
+	opt="--qnum=$QNUM2 $NFQWS_OPT_DESYNC_QUIC"
+	do_nfqws $1 100 "$opt"
+}
+zapret_custom_firewall()
+{
+	# $1 - 1 - run, 0 - stop
+
+	local MODE_OVERRIDE=nfqws
+	local f
+	local first_packets_only="-m connbytes --connbytes-dir=original --connbytes-mode=packets --connbytes 1:3"
+	local desync="-m mark ! --mark $DESYNC_MARK/$DESYNC_MARK"
+
+	zapret_do_firewall_rules_ipt $1
+
+	f="-p udp --dport 443"
+	fw_nfqws_post $1 "$f $desync $first_packets_only" "$f $desync $first_packets_only" $QNUM2
+  fw_nfqws_quic $1 "$f -m mark --mark $DESYNC_MARK/$DESYNC_MARK"
+}
+zapret_custom_firewall_nft()
+{
+	# stop logic is not required
+
+	local MODE_OVERRIDE=nfqws
+	local f
+	local first_packets_only="ct original packets 1-3"
+	local desync="mark and $DESYNC_MARK == 0"
+
+	zapret_apply_firewall_rules_nft
+
+	f="udp dport 443"
+	nft_fw_nfqws_post "$f $desync $first_packets_only" "$f $desync $first_packets_only" $QNUM2
+	nft_fw_nfqws_quic "$f mark and $DESYNC_MARK == $DESYNC_MARK"
+}

--- a/init.d/keenetic/custom-reuse-builtin-mode
+++ b/init.d/keenetic/custom-reuse-builtin-mode
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# this custom script demonstrates how to reuse built-in modes and add something from yourself
+
+MY_TPPORT=$(($TPPORT + 1))
+MY_TPWS_OPT="--methodeol --hostcase"
+MY_DPORT=81
+
+zapret_custom_daemons()
+{
+	# $1 - 1 - run, 0 - stop
+
+	local MODE_OVERRIDE=tpws
+	local opt
+
+	zapret_do_daemons $1
+
+	opt="--port=$MY_TPPORT $MY_TPWS_OPT"
+	filter_apply_hostlist_target opt
+	do_tpws $1 100 "$opt"
+}
+zapret_custom_firewall()
+{
+	# $1 - 1 - run, 0 - stop
+
+	local MODE_OVERRIDE=tpws
+	local f4 f6
+
+	zapret_do_firewall_rules_ipt $1
+
+	f4="-p tcp --dport $MY_DPORT"
+	f6=$f4
+	filter_apply_ipset_target f4 f6
+	fw_tpws $1 "$f4" "$f6" $MY_TPPORT
+}
+zapret_custom_firewall_nft()
+{
+	# stop logic is not required
+
+	local MODE_OVERRIDE=tpws
+	local f4 f6
+
+	zapret_apply_firewall_rules_nft
+
+	f4="tcp dport $MY_DPORT"
+	f6=$f4
+	nft_filter_apply_ipset_target f4 f6
+	nft_fw_tpws "$f4" "$f6" $MY_TPPORT
+}

--- a/init.d/keenetic/custom-tpws4http-nfqws4https
+++ b/init.d/keenetic/custom-tpws4http-nfqws4https
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# this custom script demonstrates how to apply tpws to http and nfqws to https
+# it preserves config settings : MODE_HTTP, MODE_HTTPS, MODE_FILTER, TPWS_OPT, NFQWS_OPT_DESYNC, NFQWS_OPT_DESYNC_HTTPS
+
+zapret_custom_daemons()
+{
+	# $1 - 1 - run, 0 - stop
+
+	local opt
+
+	[ "$MODE_HTTP" = "1" ] && {
+		opt="--port=$TPPORT $TPWS_OPT"
+		filter_apply_hostlist_target opt
+		do_tpws $1 1 "$opt"
+	}
+
+	[ "$MODE_HTTPS" = "1" ] && {
+		opt="--qnum=$QNUM $NFQWS_OPT_DESYNC_HTTPS"
+		filter_apply_hostlist_target opt
+		do_nfqws $1 2 "$opt"
+	}
+}
+zapret_custom_firewall()
+{
+	# $1 - 1 - run, 0 - stop
+
+	local f4 f6
+	local first_packet_only="-m connbytes --connbytes-dir=original --connbytes-mode=packets --connbytes 1:4"
+	local desync="-m mark ! --mark $DESYNC_MARK/$DESYNC_MARK"
+
+	[ "$MODE_HTTP" = "1" ] && {
+		f4="-p tcp --dport 80"
+		f6=$f4
+		filter_apply_ipset_target f4 f6
+		fw_tpws $1 "$f4" "$f6" $TPPORT
+	}
+
+	[ "$MODE_HTTPS" = "1" ] && {
+		f4="-p tcp --dport 443 $first_packet_only"
+		f6=$f4
+		filter_apply_ipset_target f4 f6
+		fw_nfqws_post $1 "$f4 $desync" "$f6 $desync" $QNUM
+		fw_nfqws_quic $1 "$f4 -m mark --mark $DESYNC_MARK/$DESYNC_MARK"
+	}
+}
+zapret_custom_firewall_nft()
+{
+	# stop logic is not required
+
+	local f4 f6
+	local first_packet_only="ct original packets 1-4"
+	local desync="mark and $DESYNC_MARK == 0"
+
+	[ "$MODE_HTTP" = "1" ] && {
+		f4="tcp dport 80"
+		f6=$f4
+		nft_filter_apply_ipset_target f4 f6
+		nft_fw_tpws "$f4" "$f6" $TPPORT
+	}
+
+	[ "$MODE_HTTPS" = "1" ] && {
+		f4="tcp dport 443 $first_packet_only"
+		f6=$f4
+		nft_filter_apply_ipset_target f4 f6
+		nft_fw_nfqws_post "$f4 $desync" "$f6 $desync" $QNUM
+		nft_fw_nfqws_quic $1 "$f4 mark and $DESYNC_MARK == $DESYNC_MARK"
+	}
+}

--- a/init.d/keenetic/functions
+++ b/init.d/keenetic/functions
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+SCRIPT=$(readlink -f "$0")
+EXEDIR=$(dirname "$SCRIPT")
+ZAPRET_BASE=$(readlink -f "$EXEDIR/../..")
+. "$ZAPRET_BASE/init.d/sysv/functions"
+
+CUSTOM_SCRIPT="$ZAPRET_BASE/init.d/keenetic/custom"
+[ -f "$CUSTOM_SCRIPT" ] && . "$CUSTOM_SCRIPT"
+
+load_kmod()
+{
+	if lsmod | grep "$1" &> /dev/null ;  then
+		echo "$1.ko is already loaded"
+	else
+		if insmod "/lib/modules/$(uname -r)/$1.ko" &> /dev/null; then
+			echo "$1.ko loaded"
+		else
+			echo "Cannot find $1.ko kernel module, aborting"
+			exit 1
+		fi
+	fi
+}
+
+# Fix local source ip issue when quic packets were sent with raw sockets (no Keenetic-specific iptable marks were applied)
+fw_nfqws_quic()
+{
+		# $1 - 1 - add, 0 - del
+		# $2 - iptable filter
+
+		ipt_print_op $1 "$2" "nfqws quic masquerade"
+
+		rule="$2 -d 0/0 -j MASQUERADE"
+		if [ -n "$IFACE_WAN" ] ; then
+			for wan in $IFACE_WAN; do
+				ipt_add_del $1 POSTROUTING -t nat -o $wan $rule
+			done
+		else
+			ipt_add_del $1 POSTROUTING -t nat $rule
+		fi
+}
+
+nft_fw_nfqws_quic()
+{
+	echo "Quic through nft is not supported"
+}

--- a/init.d/keenetic/netfilter.hook.sh
+++ b/init.d/keenetic/netfilter.hook.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+[ "$type" == "ip6tables" ] && exit 0
+[ "$table" != "mangle" ] && exit 0
+
+SCRIPT=$(readlink /opt/etc/init.d/S99zapret)
+if [ -n "$SCRIPT" ]; then
+	EXEDIR=$(dirname "$SCRIPT")
+	ZAPRET_BASE=$(readlink -f "$EXEDIR/../..")
+else
+	ZAPRET_BASE=/opt/zapret
+fi
+
+. "$EXEDIR/functions"
+
+case $MODE in
+	nfqws|twps|custom)
+		zapret_apply_firewall
+	;;
+esac

--- a/init.d/keenetic/zapret
+++ b/init.d/keenetic/zapret
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+SCRIPT=$(readlink -f "$0")
+EXEDIR=$(dirname "$SCRIPT")
+ZAPRET_BASE=$(readlink -f "$EXEDIR/../..")
+. "$EXEDIR/functions"
+
+do_start()
+{
+	sysctl -w "net.netfilter.nf_conntrack_checksum=0"
+	load_kmod xt_string
+	load_kmod xt_NFQUEUE
+	load_kmod xt_multiport
+	load_kmod xt_owner
+	load_kmod xt_connbytes
+	zapret_run_daemons
+	[ "$INIT_APPLY_FW" != "1" ] || { zapret_apply_firewall; }
+}
+do_stop()
+{
+	sysctl -w "net.netfilter.nf_conntrack_checksum=1"
+	zapret_stop_daemons
+	[ "$INIT_APPLY_FW" != "1" ] || zapret_unapply_firewall
+}
+
+case $1 in
+		start)
+				do_start
+				;;
+		stop|kill)
+				do_stop
+				;;
+	restart)
+		"$0" stop
+		"$0" start
+		;;
+		*)
+				echo -e "Usage: $0 (start|stop|restart)" >&2
+				exit 1
+				;;
+esac
+
+exit 0

--- a/uninstall_easy.sh
+++ b/uninstall_easy.sh
@@ -73,6 +73,17 @@ remove_macos()
 	crontab_del
 }
 
+remove_keenetic()
+{
+  KEENETIC_NETFILTER_HOOK_DST=/opt/etc/ndm/netfilter.d/zapret.sh
+
+  clear_ipset
+  remove_keenetic_netfilter_hook
+  service_remove_keenetic
+  nft_del_table
+  crontab_del
+}
+
 
 fix_sbin_path
 check_system
@@ -95,6 +106,9 @@ case $SYSTEM in
 		;;
 	macos)
 		remove_macos
+		;;
+	keenetic)
+		remove_keenetic
 		;;
 esac
 


### PR DESCRIPTION
Делюсь своей наработкой по запуску на роутерах кинетик с оперативной памятью 256MB+ и USB через Entware. 

Проводил тесты в течение более года на KN-1810 (Ultra), один провайдер, стандартная конфигурация. 
Работает стабильно, не отваливается, поэтому думаю, что стоит доработать по необходимости и попробовать интегрировать в основной репозиторий.

Для запуска используются стандартные `sysv ` скрипты с дополнениями под кинетик, загружающие необходимые модули ядра.

Требуются вручную установить компонент `Пакет расширения Xtables-addons для Netfilter`, потому, что для работы nfwq необходимы следующие модули:
- xt_string
- xt_NFQUEUE
- xt_multiport
- xt_owner
- xt_connbytes


Я попытался автоматизировать процесс установки и добавил соответствующие скрипты в install_easy.sh поэтому процесс установки должен происходить достаточно просто.

Что я менял в config после установки:
```
FWTYPE=iptables
MODE=nfqws
MODE_HTTP=0
MODE_FILTER=hostlist
NFQWS_OPT_DESYNC="ваша строка"
IFACE_LAN=br0
IFACE_WAN=ppp0
GETLIST=get_antizapret_domains.sh
```

**Нюансы:**
В процессе работы время от времени замечал утечку по памяти и пришел к выводу, что её дает компонент `Ping Check`, поэтому при возникновении такой же ситуации попробуйте либо изменить режим проверки, либо отказаться от него.

В чём цель данного PR:
----
- Привлечь интерес сообщества владельцев кинетиков
- Отладить и довести до совершенства процесс установки на большем количестве роутеров серии кинетик
- Написать гайд по самым частым вопросам
- Запустить на встроенном флеш (роутеры без USB)
- Попробовать запустить на роутерах со 128МБ памяти (маловероятно)

Чем я не собираюсь заниматься:
---
- Как установить Entware на роутер
- Как настроить роутер
- Как настроить сам zapret (правила обхода)