### PR TITLE
nfq: divert fixes for FreeBSD 14

### DIFF
--- a/nfq/darkmagic.c
+++ b/nfq/darkmagic.c
@@ -899,7 +899,12 @@ static int rawsend_socket_divert(sa_family_t family)
 	// we either have to go to the link layer (its hard, possible problems arise, compat testing, ...) or use some HACKING
 	// from my point of view disabling direct ability to send ip frames is not security. its SHIT
 
-	int fd = socket(family, SOCK_RAW, IPPROTO_DIVERT);
+	int fd;
+#if __FreeBSD_version >= 1400066 && defined(PF_DIVERT)
+	fd = socket(PF_DIVERT, SOCK_RAW, 0);
+#else
+	fd = socket(family, SOCK_RAW, IPPROTO_DIVERT);
+#endif
 	if (fd!=-1 && !set_socket_buffers(fd,4096,RAW_SNDBUF))
 	{
 		close(fd);

--- a/nfq/darkmagic.c
+++ b/nfq/darkmagic.c
@@ -918,6 +918,10 @@ static int rawsend_sendto_divert(sa_family_t family, int sock, const void *buf, 
 	socklen_t slen;
 
 	memset(&sa,0,sizeof(sa));
+#if __FreeBSD_version >= 1400066 && defined(PF_DIVERT)
+	sa.ss_family = AF_INET;
+	slen = sizeof(struct sockaddr_in);
+#else
 	sa.ss_family = family;
 	switch(family)
 	{
@@ -930,6 +934,7 @@ static int rawsend_sendto_divert(sa_family_t family, int sock, const void *buf, 
 		default:
 			return -1;
 	}
+#endif
 	return sendto(sock, buf, len, 0, (struct sockaddr*)&sa, slen);
 }
 #endif

--- a/nfq/nfqws.c
+++ b/nfq/nfqws.c
@@ -347,7 +347,11 @@ static int dvt_main()
 		bp4.sin_addr.s_addr = INADDR_ANY;
 	
 		printf("creating divert4 socket\n");
+#if __FreeBSD_version >= 1400066 && defined(PF_DIVERT)
+		fd[0] = socket(PF_DIVERT, SOCK_RAW, 0);
+#else
 		fd[0] = socket(AF_INET, SOCK_RAW, IPPROTO_DIVERT);
+#endif
 		if (fd[0] == -1) {
 				perror("socket (DIVERT4)");
 			goto exiterr;


### PR DESCRIPTION
Disclaimer: I tested only the basic usage on dvtws, and "blind fix"
in nfq/darkmagic seems to work fine with fake,split & ttl on AS12389.