### PR TITLE
Give up making attemps to test domain in case of an error

### DIFF
--- a/blockcheck.sh
+++ b/blockcheck.sh
@@ -452,6 +452,9 @@ curl_test()
 			continue
 		}
 		code=$?
+		if [ $code != 0 ]; then
+			break
+		fi
 	done
 	if [ $code = 254 ]; then
 		echo "UNAVAILABLE"


### PR DESCRIPTION
If a website is unavailable, then we didn't bypass a DPI, so it makes no sence to do additional attempts.
This speedups checks when an ISP have load balancing or multiple DPIs and we repeat the test, for example, 20 times.

In other words: We should do additional attempts only if a domain is **available**.