### PR TITLE
ip2net: fix suboptimal ip6_and

### DIFF
--- a/ip2net/ip2net.c
+++ b/ip2net/ip2net.c
@@ -178,15 +178,10 @@ static void ip6_and(const struct in6_addr *a, const struct in6_addr *b, struct i
 #if defined(__GNUC__) && !defined(__llvm__)
 __attribute__((optimize ("no-strict-aliasing")))
 #endif
-static void ip6_and(const struct in6_addr *a, const struct in6_addr *b, struct in6_addr *result)
+static void ip6_and(const struct in6_addr *restrict a, const struct in6_addr *restrict b, struct in6_addr *restrict result)
 {
-#ifdef __SIZEOF_INT128__
-	// gcc and clang have 128 bit int types on some 64-bit archs. take some advantage
-	*((unsigned __int128*)result->s6_addr) = *((unsigned __int128*)a->s6_addr) & *((unsigned __int128*)b->s6_addr);
-#else
 	((uint64_t*)result->s6_addr)[0] = ((uint64_t*)a->s6_addr)[0] & ((uint64_t*)b->s6_addr)[0];
 	((uint64_t*)result->s6_addr)[1] = ((uint64_t*)a->s6_addr)[1] & ((uint64_t*)b->s6_addr)[1];
-#endif
 }
 
 static void rtrim(char *s)


### PR DESCRIPTION
There's no benefit at best from using "native" 128-bit integers as they are just pairs of 64-bit ones underneath (sometimes they even lead to worse machine code).
`restrict`, however, allows the compilers (both gcc and clang) to use SSE/NEON instructions.