### PR TITLE
Fix get_antizapret_domains.sh URL

### DIFF
--- a/ipset/get_antizapret_domains.sh
+++ b/ipset/get_antizapret_domains.sh
@@ -11,7 +11,7 @@ getipban || FAIL=1
 "$IPSET_DIR/create_ipset.sh"
 [ -n "$FAIL" ] && exit
 
-ZURL=https://antizapret.prostovpn.org/domains-export.txt
+ZURL=https://antizapret.prostovpn.org:8443/domains-export.txt
 ZDOM="$TMPDIR/zapret.txt"
 
 


### PR DESCRIPTION
Исправление для скачивания списка антизапрета. Без него получаем:
```bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
curl: (28) SSL connection timeout
```