### PR TITLE
feat (blockcheck): add ask skip timeout

### DIFF
--- a/blockcheck.sh
+++ b/blockcheck.sh
@@ -869,6 +869,10 @@ curl_test()
 			[ $REPEATS -gt 1 ] && echo 'AVAILABLE'
 		else
 			code=$?
+			if [ "$TIMEOUT_FLAG" = "Y" ] && [ $code -eq 28 ]; then
+				echo "Timeout occurred. Interrupting further attempts."
+				break
+			fi
 			[ "$SCANLEVEL" = quick ] && break
 		fi
 	done
@@ -1587,6 +1591,10 @@ ask_params()
 		ask_yes_no_var IGNORE_CA "do not verify server certificate"
 		[ "$IGNORE_CA" = 1 ] && CURL_OPT=-k
 	}
+
+	TIMEOUT_FLAG=N
+	echo
+	ask_yes_no_var TIMEOUT_FLAG "Interrupt on timeout (Y/N) [default: N]"
 
 	echo
 	echo "sometimes ISPs use multiple DPIs or load balancing. bypass strategies may work unstable."

--- a/blockcheck.sh
+++ b/blockcheck.sh
@@ -869,7 +869,7 @@ curl_test()
 			[ $REPEATS -gt 1 ] && echo 'AVAILABLE'
 		else
 			code=$?
-			if [ "$TIMEOUT_FLAG" = "Y" ] && [ $code -eq 28 ]; then
+			if [ "$TIMEOUT_FLAG" = 1 ] && [ $code -eq 28 ]; then
 				echo "Timeout occurred. Interrupting further attempts."
 				break
 			fi
@@ -1592,10 +1592,6 @@ ask_params()
 		[ "$IGNORE_CA" = 1 ] && CURL_OPT=-k
 	}
 
-	TIMEOUT_FLAG=N
-	echo
-	ask_yes_no_var TIMEOUT_FLAG "Interrupt on timeout (Y/N) [default: N]"
-
 	echo
 	echo "sometimes ISPs use multiple DPIs or load balancing. bypass strategies may work unstable."
 	printf "how many times to repeat each test (default: 1) : "
@@ -1605,6 +1601,12 @@ ask_params()
 		echo invalid repeat count
 		exitp 1
 	}
+
+	TIMEOUT_FLAG=0
+	if [ "$REPEATS" -gt 1 ]; then
+		echo
+		ask_yes_no_var TIMEOUT_FLAG "Interrupt on timeout"
+	fi
 
 	echo
 	echo quick    - scan as fast as possible to reveal any working strategy


### PR DESCRIPTION
Enable Timeout Interruption in blockcheck.sh 

When prompted during execution, the user can choose Y to interrupt further attempts if a timeout occurs:
`Interrupt on timeout (Y/N) [default: N] : Y`

**example**
before
```
- checking tpws --hostspell=hoSt         
[attempt 1] curl: (28) Operation timed out after 2006 milliseconds with 0 bytes received
[attempt 2] curl: (28) Operation timed out after 2004 milliseconds with 0 bytes received
[attempt 3] curl: (28) Operation timed out after 2005 milliseconds with 0 bytes received
UNAVAILABLE code=28
```
after
```
- checking tpws --hostspell=hoSt         
[attempt 1] curl: (28) Operation timed out after 2006 milliseconds with 0 bytes received
Timeout occurred. Interrupting further attempts.
```
