### PR TITLE
blockcheck.sh пропуск попыток для стандартного режима

### DIFF
--- a/blockcheck.sh
+++ b/blockcheck.sh
@@ -974,7 +974,7 @@ curl_test()
 			[ $REPEATS -gt 1 ] && echo 'AVAILABLE'
 		else
 			code=$?
-			[ "$SCANLEVEL" = quick ] && break
+			[ "$SCANLEVEL" != force ] && break
 		fi
 	done
 	[ "$4" = detail ] || {


### PR DESCRIPTION
Думаю, что было бы правильно пропускать заведомо ошибочные сценарии не только в quick сценарии, но и в standard