### PR TITLE
init.d/sysv: set usage helper to show actual path

### DIFF
--- a/init.d/sysv/zapret
+++ b/init.d/sysv/zapret
@@ -74,8 +74,7 @@ case "$1" in
 		;;
 		
   *)
-	N=/etc/init.d/$NAME
-	echo "Usage: $N {start|stop|restart|start-fw|stop-fw|restart-fw|start-daemons|stop-daemons|restart-daemons|reload-ifsets|list-ifsets|list-table}" >&2
+	echo "Usage: $SCRIPT {start|stop|restart|start-fw|stop-fw|restart-fw|start-daemons|stop-daemons|restart-daemons|reload-ifsets|list-ifsets|list-table}" >&2
 	exit 1
 	;;
 esac


### PR DESCRIPTION
Zapret не всегда может находиться в /etc/init.d, использование переменной SCRIPT избавит от создание dummy переменной N и покажет настоящий путь до исполняемого файла