### PR TITLE
nfqws: optimized Cloudflare filtering ones

### DIFF
--- a/init.d/custom.d.examples.linux/50-cloudflare
+++ b/init.d/custom.d.examples.linux/50-cloudflare
@@ -1,0 +1,55 @@
+NFQWS_CLOUDFLARE_OPTS="${NFQWS_CLOUDFLARE_OPTS:---dpi-desync=fake --dpi-desync-repeats=6 --dpi-desync-any-protocol}"
+NFQWS_CLOUDFLARE_PORTS=${NFQWS_CLOUDFLARE_PORTS:-443,80}
+NFQWS_CLOUDFLARE_SUBNETS="103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 104.16.0.0/13 104.24.0.0/14 108.162.192.0/18 131.0.72.0/22 141.101.64.0/18 162.158.0.0/15 172.64.0.0/13 173.245.48.0/20 188.114.96.0/20 190.93.240.0/20 197.234.240.0/22 198.41.128.0/17"
+
+alloc_dnum DNUM_NFQWS_CLOUDFLARE
+alloc_qnum QNUM_NFQWS_CLOUDFLARE
+NFQWS_CLOUDFLARE_SET_NAME=cloudflare_nfqws
+
+zapret_custom_daemons()
+{
+	local opt="--qnum=$QNUM_NFQWS_CLOUDFLARE $NFQWS_CLOUDFLARE_OPTS"
+	do_nfqws $1 $DNUM_NFQWS_CLOUDFLARE "$opt"
+}
+
+zapret_custom_firewall()
+{
+	local first_packets_only="$ipt_connbytes 1:3"
+	local dest_set="-m set --match-set $NFQWS_CLOUDFLARE_SET_NAME dst"
+	local subnet
+
+	[ "$1" = 1 ] && {
+		ipset create $NFQWS_CLOUDFLARE_SET_NAME hash:net hashsize 8192 maxelem 4096 2>/dev/null
+		ipset flush $NFQWS_CLOUDFLARE_SET_NAME
+		for subnet in $NFQWS_CLOUDFLARE_SUBNETS; do
+			echo add $NFQWS_CLOUDFLARE_SET_NAME $subnet
+		done | ipset -! restore
+	}
+
+	local f="-p tcp -m multiport --dports $NFQWS_CLOUDFLARE_PORTS"
+	fw_nfqws_post $1 "$f $first_packets_only $dest_set" "" $QNUM_NFQWS_CLOUDFLARE
+
+	[ "$1" = 1 ] || {
+		ipset destroy $NFQWS_CLOUDFLARE_SET_NAME 2>/dev/null
+	}
+}
+
+zapret_custom_firewall_nft()
+{
+	local first_packets_only="$nft_connbytes 1-3"
+	local dest_set="ip daddr @$NFQWS_CLOUDFLARE_SET_NAME"
+	local subnets
+
+	make_comma_list subnets $NFQWS_CLOUDFLARE_SUBNETS
+	nft_create_set $NFQWS_CLOUDFLARE_SET_NAME "type ipv4_addr; size 4096; auto-merge; flags interval;"
+	nft_flush_set $NFQWS_CLOUDFLARE_SET_NAME
+	nft_add_set_element $NFQWS_CLOUDFLARE_SET_NAME "$subnets"
+
+	local f="tcp dport {$NFQWS_CLOUDFLARE_PORTS}"
+	nft_fw_nfqws_post "$f $first_packets_only $dest_set" "" $QNUM_NFQWS_CLOUDFLARE
+}
+
+zapret_custom_firewall_nft_flush()
+{
+	nft_del_set $NFQWS_CLOUDFLARE_SET_NAME 2>/dev/null
+}


### PR DESCRIPTION
Добавленный скрипт добавляет поддержку `nfqws`-фильтрации для официальных диапазонов IP-адресов Cloudflare. Он использует `ipset` для группировки подсетей и применяет `iptables`/`nftables`-правила, направляя соответствующий трафик в `nfqws`.

Исправляет проблемы с доступом к сайтам, которые находятся за Cloudflare-ом, необходимые <ins>для работы</ins>. Проблема замечена на МГТС (MTS Home) и Ростелекоме с 02.04.2025