### PR TITLE
Исправлен install_easy.sh для apple silicon

### DIFF
--- a/install_easy.sh
+++ b/install_easy.sh
@@ -101,9 +101,22 @@ check_bins()
 				;;
 		esac
 		CFLAGS="-march=native ${CFLAGS}" make -C "$EXEDIR" $make_target || {
-			echo could not compile
-			make -C "$EXEDIR" clean
-			exitp 8
+			if [ "$SYSTEM" = macos ]; then
+					echo "retrying compile"
+					echo "removing quarantine attributes"
+					xattr -d com.apple.quarantine ./binaries/mac64/ip2net 2>/dev/null
+					xattr -d com.apple.quarantine ./binaries/mac64/mdig 2>/dev/null
+					xattr -d com.apple.quarantine ./binaries/mac64/tpws 2>/dev/null
+					make -C "$EXEDIR" $make_target || {
+						echo could not compile
+						make -C "$EXEDIR" clean 2>/dev/null
+						exitp 8
+					}
+			else
+				echo could not compile
+				make -C "$EXEDIR" clean 2>/dev/null
+				exitp 8
+			fi
 		}
 		echo compiled
 	else


### PR DESCRIPTION
Использующийся для сборки clang не распознаёт архитектуру apple-silicon (apple-m1 и тп) как допустимое значение для -march. Поэтому я добавил повторную попытку сборки без использования -march (на macOS особый Apple CLang, и всё должно без проблем собираться без дополнительных флагов). 

Также источник проблемы часто заключается в SIP и XProtect: эти системы могут отправлять взаимодействующие с сетью файлы в карантин, это я тоже исправил, вытаскивая бинарники из карантина через xattr (вывод перенаправлен в null, чтобы избежать вывода ошибок на случай, если карантин всё таки пуст).

Все эти изменения будут применимы только к macOS, для остальных систем ничего не менял. Если macOS на Intel, то такой ошибки по идее быть вообще не должно (SIP и XProtect лучше всего работают именно на apple-silicon), а значит изменения не должны повлиять на macOS с x64_86 архитектурой. 

Ещёперенаправил make clean в null, чтобы уменьшить объём мусора в терминале. Все внесённые изменения протестированы на macOS с процессорами M1 и M2.