### PR TITLE
init.d: openwrt-minimal: redirect https connections to another port

### DIFF
--- a/init.d/openwrt-minimal/tpws/etc/firewall.user
+++ b/init.d/openwrt-minimal/tpws/etc/firewall.user
@@ -1,5 +1,6 @@
 DISABLE_IPV6=0
 TP_PORT=900
+TP_PORT_SSL=901
 TP_USER=daemon
 
 EXCLUDE4="10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16 127.0.0.0/8"
@@ -25,7 +26,7 @@ redirect_port()
 redirect()
 {
 	redirect_port 80 $TP_PORT
-	redirect_port 443 $TP_PORT
+	redirect_port 443 $TP_PORT_SSL
 }
 
 for IPTABLES in $IPTS; do

--- a/init.d/openwrt-minimal/tpws/etc/nftables.d/90-tpws.nft
+++ b/init.d/openwrt-minimal/tpws/etc/nftables.d/90-tpws.nft
@@ -8,11 +8,15 @@ set tpws_exclude6 {
 }
 chain tpws_pre {
 	type nat hook prerouting priority dstnat; policy accept;
-	tcp dport {80,443} ip daddr != @tpws_exclude4 redirect to :900
-	tcp dport {80,443} ip6 daddr != @tpws_exclude6 redirect to :900
+	tcp dport 80 ip daddr != @tpws_exclude4 redirect to :900
+	tcp dport 443 ip daddr != @tpws_exclude4 redirect to :901
+	tcp dport 80 ip6 daddr != @tpws_exclude4 redirect to :900
+	tcp dport 443 ip6 daddr != @tpws_exclude6 redirect to :901
 }
 chain tpws_out {
 	type nat hook output priority -100; policy accept;
-	tcp dport {80,443} skuid != daemon ip daddr != @tpws_exclude4 redirect to :900
-	tcp dport {80,443} skuid != daemon ip6 daddr != @tpws_exclude6 redirect to :900
+	tcp dport 80 skuid != daemon ip daddr != @tpws_exclude4 redirect to :900
+	tcp dport 443 skuid != daemon ip daddr != @tpws_exclude4 redirect to :901
+	tcp dport 80 skuid != daemon ip6 daddr != @tpws_exclude6 redirect to :900
+	tcp dport 443 skuid != daemon ip6 daddr != @tpws_exclude6 redirect to :901
 }


### PR DESCRIPTION
Firewall rules for redirecting HTTPS traffic redirect it to the 900 port, which is used for parsing HTTP traffic, so only plain HTTP works. I've changed firewall rules, so now HTTPS traffic is going to the 901 port.

Правила файрвола для перенаправления трафика HTTPS перенаправляют его на порт 900, который используется для обработки HTTP-трафика, так что только он и работает. Я поменял правила файрвола, так что теперь HTTPS-трафик идёт на порт 901.