### PR TITLE
Fix the annoying typo that got me confused on my attempt to set up

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1665,7 +1665,7 @@ LISTS_RELOAD=-  отключает перезагрузку листов.
 
 В системе запуска это обыграно следующим образом.
 Присутствуют 2 include списка :
-`ipset/zapret-hosts-users.txt.gz` или `ipset/zapret-hosts-users.txt`,
+`ipset/zapret-hosts-user.txt.gz` или `ipset/zapret-hosts-user.txt`,
 `ipset/zapret-hosts.txt.gz` или `ipset/zapret-hosts.txt`
 и 1 exclude список
 `ipset/zapret-hosts-user-exclude.txt.gz` или `ipset/zapret-hosts-user-exclude.txt`


### PR DESCRIPTION
Please correct this typo in the file name, as it caused me to stumble twice when setting up zapret. I took the file name directly from the readme, and then I found out that it was incorrect. Then after a while I forgot about it and took the file name from the readme again. So I decided to make a pull request.