### PR TITLE
WIP: Добавлен фильтр по LAN интефрейсу

### DIFF
--- a/common/nft.sh
+++ b/common/nft.sh
@@ -474,7 +474,7 @@ _nft_fw_nfqws_post4()
 	[ "$DISABLE_IPV4" = "1" -o -z "$1" ] || {
 		local filter="$1" port="$2" rule chain=$(get_postchain) setmark
 		nft_print_op "$filter" "nfqws postrouting (qnum $port)" 4
-		rule="${3:+oifname @wanif} $(nft_mark_filter) $filter ip daddr != @nozapret"
+		rule="${3:+oifname @wanif} ${4:+iifname @lanif} $(nft_mark_filter) $filter ip daddr != @nozapret"
 		is_postnat && setmark="meta mark set meta mark or $DESYNC_MARK_POSTNAT"
 		nft_insert_rule $chain $rule $setmark $CONNMARKER $FW_EXTRA_POST queue num $port bypass
 		nft_add_nfqws_flow_exempt_rule "$rule"

--- a/init.d/sysv/functions
+++ b/init.d/sysv/functions
@@ -133,7 +133,7 @@ nft_fw_tpws6()
 }
 nft_fw_nfqws_post4()
 {
-	_nft_fw_nfqws_post4 "$1" $2 "$IFACE_WAN"
+	_nft_fw_nfqws_post4 "$1" $2 "$IFACE_WAN" "$IFACE_LAN"
 }
 nft_fw_nfqws_post6()
 {


### PR DESCRIPTION
Добрый день, заметил что в zapret в конфигурации nfqws и nftables не используется переменная конфига IFACE_LAN. Так получилось что для моего сервера было необходимо ограничить zapret определёнными интерфейсами. Тестил как с пустой переменной, так и с несколькими интерфейсами. С этим небольшим патчем оно заработало, но ставлю WIP т.к. не знаю, сломает ли оно что-нибудь.