### PR TITLE
Добавление функции altsni: рандомизация домена в SNI для фейкового TLS

### DIFF
--- a/nfq/params.c
+++ b/nfq/params.c
@@ -314,6 +314,16 @@ static void dp_clear_dynamic(struct desync_profile *dp)
 	strlist_destroy(&dp->filter_ssid);
 #endif
 	HostFailPoolDestroy(&dp->hostlist_auto_fail_counters);
+	// Clean up altsni pool if present
+	if (dp->tls_mod_last.altsni)
+	{
+		struct altsni_pool *pool = dp->tls_mod_last.altsni;
+		for (size_t i = 0; i < pool->count; i++)
+			free(pool->domains[i]);
+		free(pool->domains);
+		free(pool);
+		dp->tls_mod_last.altsni = NULL;
+	}
 	struct blob_collection_head **fake,*fakes[] = {&dp->fake_http, &dp->fake_tls, &dp->fake_unknown, &dp->fake_unknown_udp, &dp->fake_quic, &dp->fake_wg, &dp->fake_dht, &dp->fake_discord, &dp->fake_stun, NULL};
 	for(fake=fakes;*fake;fake++) blob_collection_destroy(*fake);
 }

--- a/nfq/params.h
+++ b/nfq/params.h
@@ -62,6 +62,7 @@
 #define FAKE_TLS_MOD_RND_SNI		0x40
 #define FAKE_TLS_MOD_SNI		0x80
 #define FAKE_TLS_MOD_PADENCAP		0x100
+#define FAKE_TLS_MOD_ALTSNI		0x200
 
 #define FAKE_MAX_TCP	1460
 #define FAKE_MAX_UDP	1472
@@ -76,9 +77,16 @@ struct fake_tls_mod_cache
 {
 	size_t extlen_offset, padlen_offset;
 };
+struct altsni_pool
+{
+	char **domains;      // array of domain strings
+	size_t count;        // number of domains
+	size_t capacity;     // allocated capacity
+};
 struct fake_tls_mod
 {
 	char sni[128];
+	struct altsni_pool *altsni;  // pool of domains for random SNI selection
 	uint32_t mod;
 };
 struct hostfakesplit_mod


### PR DESCRIPTION
Реализовал новый модификатор для fake TLS: **altsni**
Суть проблемы сейчас такая, для большинства зарубежных CDN введены "белые списки" доменов, которые не блочатся. Чтобы получить доступ к условному рутрекеру, мы подбираем валидный домен из этого белого списка, который живет на тех же IP, и ставим его в SNI фейка. Сейчас в zapret этот домен задается статично (один на всё).
Это создает потенциальный вектор для детекта, если долбить во все CIDR какого-нибудь Cloudflare с одним и тем же SNI в фейке, ТСПУ возможно (?) начнёт подозревать неладное из-за нелегитимно большого трафика к одному единственному ресурсу. В этой реализации добавлена возможность задать пул доменов. nfqws будет рандомно выбирать один из них и на лету подставлять в ClientHello фейкового пакета, в следствие размывает сигнатуру и снижает подозрения со стороны цензора.
Технически добавился флаг --dpi-desync-fake-tls-altsni. Он принимает либо список доменов через запятую, либо путь к файлу. В коде добавлена логика парсинга пула и модификации пакета с пересчетом длин TLS-полей.

P.S. Над названием параметра --dpi-desync-fake-tls-altsni можно ещё подумать, но для понимания функционала думаю сойдёт