### PR TITLE
Enable seccomp on loongarch64

### DIFF
--- a/nfq/sec.h
+++ b/nfq/sec.h
@@ -72,6 +72,10 @@ bool dropcaps(void);
 
 # define ARCH_NR	AUDIT_ARCH_RISCV64
 
+#elif defined(__loongarch__) && __loongarch_grlen == 64
+
+# define ARCH_NR AUDIT_ARCH_LOONGARCH64
+
 #else
 
 # error "Platform does not support seccomp filter yet"

--- a/tpws/sec.h
+++ b/tpws/sec.h
@@ -74,6 +74,10 @@ bool dropcaps(void);
 
 # define ARCH_NR	AUDIT_ARCH_RISCV64
 
+#elif defined(__loongarch__) && __loongarch_grlen == 64
+
+# define ARCH_NR AUDIT_ARCH_LOONGARCH64
+
 #else
 
 # error "Platform does not support seccomp filter yet"


### PR DESCRIPTION
Hi!
This makes possible building zapret on loongarch64! Also could be applied to zapret2